### PR TITLE
Refctor readonly repository

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -23,7 +23,8 @@ Task("Restore")
     .Does(() =>
     {
     
-       var buildSettings =  new DotNetCoreBuildSettings { Configuration = configuration,
+       var buildSettings =  new DotNetCoreBuildSettings { 
+                                                          Configuration = configuration,
                                                           ArgumentCustomization = args => args.Append("--no-restore"),
                                                          };
         var projects = GetFiles("./**/*.csproj");

--- a/build.cake
+++ b/build.cake
@@ -26,20 +26,19 @@ Task("Restore")
        var buildSettings =  new DotNetCoreBuildSettings { Configuration = configuration,
                                                           ArgumentCustomization = args => args.Append("--no-restore"),
                                                          };
-                                       
-        Information("Building Test Database Project");                               
-        DotNetCoreBuild("./tests/Database/TestDatabase.csproj", buildSettings);
-        Information("Building Unit Test Project Project");  
-        DotNetCoreBuild("./tests/Threenine.Data.Tests/Threenine.Data.Tests.csproj", buildSettings);
-        Information("Building Threenine.Data Project");  
-        DotNetCoreBuild("./src/Threenine.Data.csproj", buildSettings);
-           
-    });
+        var projects = GetFiles("./**/*.csproj");
+        
+        foreach(var project in projects)
+        {
+           Information("Building Project: " + project);
+           DotNetCoreBuild(project.ToString(), buildSettings);
+        }
+      });
 
 Task("Test")
     .Does(() =>
     {
-        var projects = GetFiles("./tests/Threenine.Data.Tests/Threenine.Data.Tests.csproj");
+        var projects = GetFiles("./tests/**/*.Tests.csproj");
         foreach(var project in projects)
         {
             Information("Testing project " + project);

--- a/src/BaseRepository.cs
+++ b/src/BaseRepository.cs
@@ -80,9 +80,7 @@ namespace Threenine.Data
 
             if (predicate != null) query = query.Where(predicate);
 
-            return orderBy != null
-                ? orderBy(query).Select(selector).ToPaginate(index, size)
-                : query.Select(selector).ToPaginate(index, size);
+            return orderBy != null ? orderBy(query).Select(selector).ToPaginate(index, size): query.Select(selector).ToPaginate(index, size);
         }
     }
 }

--- a/src/IRepositoryReadOnly.cs
+++ b/src/IRepositoryReadOnly.cs
@@ -15,9 +15,32 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+using Threenine.Data.Paging;
+
 namespace Threenine.Data
 {
-    public interface IRepositoryReadOnly<T> : IReadRepository<T> where T : class
+    public interface IRepositoryReadOnly<T>  where T : class
     {
+        T SingleOrDefault(Expression<Func<T, bool>> predicate = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null
+            );
+
+        IPaginate<T> GetList(Expression<Func<T, bool>> predicate = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+            int index = 0,
+            int size = 20);
+
+        IPaginate<TResult> GetList<TResult>(Expression<Func<T, TResult>> selector,
+            Expression<Func<T, bool>> predicate = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+            int index = 0,
+            int size = 20) where TResult : class;
     }
 }

--- a/src/IRepositoryReadOnlyAsync.cs
+++ b/src/IRepositoryReadOnlyAsync.cs
@@ -1,0 +1,53 @@
+/* Copyright (c) threenine.co.uk . All rights reserved.
+ 
+   GNU GENERAL PUBLIC LICENSE  Version 3, 29 June 2007
+   This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Query;
+using Threenine.Data.Paging;
+
+namespace Threenine.Data
+{
+    public interface IRepositoryReadOnlyAsync<T> where T : class
+    {
+        
+        Task<T> SingleOrDefaultAsync(Expression<Func<T, bool>> predicate = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null
+        );
+
+        Task<IPaginate<T>> GetListAsync(Expression<Func<T, bool>> predicate = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+            int index = 0,
+            int size = 20);
+
+
+        Task<IPaginate<TResult>> GetListAsync<TResult>(Expression<Func<T, TResult>> selector,
+            Expression<Func<T, bool>> predicate = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+            int index = 0,
+            int size = 20,
+            CancellationToken cancellationToken = default,
+            bool ignoreQueryFilters = false)
+            where TResult : class;
+    }
+} 

--- a/src/IUnitOfWork.cs
+++ b/src/IUnitOfWork.cs
@@ -26,6 +26,7 @@ namespace Threenine.Data
         IRepository<TEntity> GetRepository<TEntity>() where TEntity : class;
         IRepositoryAsync<TEntity> GetRepositoryAsync<TEntity>() where TEntity : class;
         IRepositoryReadOnly<TEntity> GetReadOnlyRepository<TEntity>() where TEntity : class;
+        IRepositoryReadOnlyAsync<TEntity> GetReadOnlyRepositoryAsync<TEntity>() where TEntity : class;
 
         int Commit(bool autoHistory = false);
         Task<int> CommitAsync(bool autoHistory = false);

--- a/src/RepositoryAsync.cs
+++ b/src/RepositoryAsync.cs
@@ -83,6 +83,45 @@ namespace Threenine.Data
                 return orderBy(query).ToPaginateAsync(index, size, 0, cancellationToken);
             return query.ToPaginateAsync(index, size, 0, cancellationToken);
         }
+        
+        public  Task<IPaginate<TResult>> GetListAsync<TResult>(Expression<Func<T, TResult>> selector,
+            Expression<Func<T, bool>> predicate = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+            Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+            int index = 0,
+            int size = 20,
+            bool enableTracking = true,
+            CancellationToken cancellationToken = default,
+            bool ignoreQueryFilters = false)
+            where TResult : class
+        {
+            IQueryable<T> query = _dbSet;
+
+            if (!enableTracking) query = query.AsNoTracking();
+
+            if (include != null)
+            {
+                query = include(query);
+            }
+
+            if (predicate != null)
+            {
+                query = query.Where(predicate);
+            }
+
+            if (ignoreQueryFilters)
+            {
+                query = query.IgnoreQueryFilters();
+            }
+
+            if (orderBy != null)
+            {
+                return orderBy(query).Select(selector).ToPaginateAsync(index, size, 0, cancellationToken);
+            }
+            
+            return query.Select(selector).ToPaginateAsync(index, size, 0, cancellationToken);
+            
+        }
 
         #endregion
 

--- a/src/RepositoryReadOnly.cs
+++ b/src/RepositoryReadOnly.cs
@@ -15,7 +15,12 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+using System;
+using System.Linq;
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Threenine.Data.Paging;
 
 namespace Threenine.Data
 {
@@ -23,6 +28,22 @@ namespace Threenine.Data
     {
         public RepositoryReadOnly(DbContext context) : base(context)
         {
+        }
+
+        public T SingleOrDefault(Expression<Func<T, bool>> predicate = null, Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null, Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null)
+        {
+            return base.SingleOrDefault(predicate, orderBy,include, false);
+        }
+
+        public IPaginate<T> GetList(Expression<Func<T, bool>> predicate = null, Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null, Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null, int index = 0, int size = 20)
+        {
+            return base.GetList(predicate, orderBy, include, index, size, false);
+        }
+
+        public IPaginate<TResult> GetList<TResult>(Expression<Func<T, TResult>> selector, Expression<Func<T, bool>> predicate = null, Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null, Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+            int index = 0, int size = 20) where TResult : class
+        {
+            return base.GetList(selector, predicate, orderBy, include, index, size, false);
         }
     }
 }

--- a/src/RepositoryReadOnlyAsync.cs
+++ b/src/RepositoryReadOnlyAsync.cs
@@ -1,0 +1,59 @@
+/* Copyright (c) threenine.co.uk . All rights reserved.
+ 
+   GNU GENERAL PUBLIC LICENSE  Version 3, 29 June 2007
+   This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.Serialization.Formatters;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
+using Threenine.Data.Paging;
+
+namespace Threenine.Data
+{
+    public class RepositoryReadOnlyAsync<T>: RepositoryAsync<T>, IRepositoryReadOnlyAsync<T> where T : class
+    {
+        public RepositoryReadOnlyAsync(DbContext context) : base(context)
+        {
+        }
+
+        public async Task<T> SingleOrDefaultAsync(Expression<Func<T, bool>> predicate = null, Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null, Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null)
+        {
+           return await base.SingleOrDefaultAsync(predicate, orderBy, include, false);
+        }
+
+        public async Task<IPaginate<T>> GetListAsync(Expression<Func<T, bool>> predicate = null, Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null, Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null, int index = 0, int size = 20)
+        {
+            return await base.GetListAsync(predicate, orderBy, include, index, size, false);
+        }
+
+        public async Task<IPaginate<TResult>> GetListAsync<TResult>(Expression<Func<T, TResult>> selector,
+                                Expression<Func<T, bool>> predicate = null,
+                                Func<IQueryable<T>, IOrderedQueryable<T>> orderBy = null,
+                                Func<IQueryable<T>, IIncludableQueryable<T, object>> include = null,
+                                int index = 0,
+                                int size = 20,
+                                CancellationToken cancellationToken = default,
+                                bool ignoreQueryFilters = false) where TResult : class
+        {
+          return await base.GetListAsync(selector, predicate, orderBy, include, index,size, false,cancellationToken,ignoreQueryFilters);
+
+        }
+    }        
+
+}

--- a/src/UnitOfWork.cs
+++ b/src/UnitOfWork.cs
@@ -59,6 +59,15 @@ namespace Threenine.Data
             return (IRepositoryReadOnly<TEntity>) _repositories[type];
         }
 
+        public IRepositoryReadOnlyAsync<TEntity> GetReadOnlyRepositoryAsync<TEntity>() where TEntity : class
+        {
+            if (_repositories == null) _repositories = new Dictionary<Type, object>();
+
+            var type = typeof(TEntity);
+            if (!_repositories.ContainsKey(type)) _repositories[type] = new RepositoryReadOnlyAsync<TEntity>(Context);
+            return (IRepositoryReadOnlyAsync<TEntity>) _repositories[type];
+        }
+
         public TContext Context { get; }
 
         public int Commit(bool autoHistory = false)

--- a/tests/Threenine.Data.Tests/ReadOnlyRepositoryTests.cs
+++ b/tests/Threenine.Data.Tests/ReadOnlyRepositoryTests.cs
@@ -41,6 +41,16 @@ namespace Threenine.Data.Tests
         private readonly SqlLiteWith20ProductsTestFixture _fixture;
 
         [Fact]
+        public void ShouldReturnInstanceIfInterface()
+        {
+            using var uow = new UnitOfWork<TestDbContext>(_fixture.Context);
+            var repo = uow.GetReadOnlyRepository<TestProduct>();
+
+            Assert.IsAssignableFrom<IRepositoryReadOnly<TestProduct>>(repo);
+
+        }
+        
+        [Fact]
         public void ShouldGetItems()
         {
             using var uow = new UnitOfWork<TestDbContext>(_fixture.Context);
@@ -73,5 +83,6 @@ namespace Threenine.Data.Tests
 
             Assert.Null(product);
         }
+        
     }
 }

--- a/tests/Threenine.Data.Tests/RepositoryReadOnlyAsyncTests.cs
+++ b/tests/Threenine.Data.Tests/RepositoryReadOnlyAsyncTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading.Tasks;
+using TestDatabase;
+using Threenine.Data.Tests.TestFixtures;
+using Xunit;
+
+namespace Threenine.Data.Tests
+{
+    [Collection(GlobalTestStrings.ProductCollectionName)]
+    public class RepositoryReadOnlyAsyncTests : IDisposable
+    {
+        private readonly SqlLiteWith20ProductsTestFixture _fixture;
+        
+        public RepositoryReadOnlyAsyncTests(SqlLiteWith20ProductsTestFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        public void Dispose()
+        {
+            _fixture?.Dispose();
+        }
+
+        [Fact]
+        public void ShouldReturnInstanceIfInterface()
+        {
+            using var uow = new UnitOfWork<TestDbContext>(_fixture.Context);
+            var repo = uow.GetReadOnlyRepositoryAsync<TestProduct>();
+
+            Assert.IsAssignableFrom<IRepositoryReadOnlyAsync<TestProduct>>(repo);
+        }
+        
+        [Fact]
+        public async Task ShouldGetItems()
+        {
+            using var uow = new UnitOfWork<TestDbContext>(_fixture.Context);
+            var repo = uow.GetReadOnlyRepositoryAsync<TestProduct>();
+
+            var product = await repo.SingleOrDefaultAsync(x => x.Id == 1);
+
+            Assert.NotNull(product);
+        }
+    }
+}

--- a/tests/Threenine.Data.Tests/RepositoryReadOnlyTests.cs
+++ b/tests/Threenine.Data.Tests/RepositoryReadOnlyTests.cs
@@ -26,9 +26,9 @@ using Xunit;
 namespace Threenine.Data.Tests
 {
     [Collection(GlobalTestStrings.ProductCollectionName)]
-    public class ReadOnlyRepositoryTests : IDisposable
+    public class RepositoryReadOnlyTests : IDisposable
     {
-        public ReadOnlyRepositoryTests(SqlLiteWith20ProductsTestFixture fixture)
+        public RepositoryReadOnlyTests(SqlLiteWith20ProductsTestFixture fixture)
         {
             _fixture = fixture;
         }


### PR DESCRIPTION

## Overview: 

Refactored the ReadOnly Repository to hide the enable tracking flag, to ensure the readonly repository only returns values that are not tracked by the Unit of work

## Work carried out:


- [x] Updated IReadOnlyRepository to have its own methods


